### PR TITLE
FHG-2884 Check details UI

### DIFF
--- a/src/FamilyHubs.Referral.Core/FamilyHubs.Referral.Core.csproj
+++ b/src/FamilyHubs.Referral.Core/FamilyHubs.Referral.Core.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+	  <PackageReference Include="libphonenumber-csharp" Version="8.13.11" />
+	  <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="2.0.4" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.55.0.65544">
       <PrivateAssets>all</PrivateAssets>

--- a/src/FamilyHubs.Referral.Core/FamilyHubs.Referral.Core.csproj
+++ b/src/FamilyHubs.Referral.Core/FamilyHubs.Referral.Core.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
 	  <PackageReference Include="libphonenumber-csharp" Version="8.13.11" />
     <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="2.0.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.55.0.65544">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.0.0.68202">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/FamilyHubs.Referral.Core/FamilyHubs.Referral.Core.csproj
+++ b/src/FamilyHubs.Referral.Core/FamilyHubs.Referral.Core.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
 	  <PackageReference Include="libphonenumber-csharp" Version="8.13.11" />
-	  <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FamilyHubs.ServiceDirectory.Shared" Version="2.0.4" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.55.0.65544">
       <PrivateAssets>all</PrivateAssets>

--- a/src/FamilyHubs.Referral.Core/Models/ConnectionRequestModel.cs
+++ b/src/FamilyHubs.Referral.Core/Models/ConnectionRequestModel.cs
@@ -1,7 +1,8 @@
 ﻿
 namespace FamilyHubs.Referral.Core.Models;
 
-public enum ConnectJourneyPage
+//todo: merge into one
+public enum ConnectContactDetailsJourneyPage
 {
     Email,
     Telephone,
@@ -16,7 +17,7 @@ public class ConnectionRequestModel
     public string? ServiceId { get; set; }
     public string? FamilyContactFullName { get; set; }
     public string? Reason { get; set; }
-    public bool[] ContactMethodsSelected { get; set; } = new bool[(int)ConnectJourneyPage.LastContactMethod+1];
+    public bool[] ContactMethodsSelected { get; set; } = new bool[(int)ConnectContactDetailsJourneyPage.LastContactMethod+1];
     public string? EmailAddress { get; set; }
     public string? TelephoneNumber { get; set; }
     public string? TextphoneNumber { get; set; }

--- a/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsPostcodeAttribute.cs
+++ b/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsPostcodeAttribute.cs
@@ -38,7 +38,7 @@ public class UKGdsPostcodeAttribute : ValidationAttribute
 
             if (!SimpleValidUkPostcodeRegex.IsMatch(postcode))
             {
-                return new ValidationResult("Enter a real postcode.");
+                return new ValidationResult("Enter a real postcode");
             }
         }
 

--- a/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsPostcodeAttribute.cs
+++ b/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsPostcodeAttribute.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace FamilyHubs.Referral.Core.ValidationAttributes;
 
-public class UKGdsPostcodeAttribute : ValidationAttribute
+public class UkGdsPostcodeAttribute : ValidationAttribute
 {
     // This is a simple 'does it look like a postcode' check.
     // We could use a more complex regex to check for valid postcodes,

--- a/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsTelephoneNumberAttribute.cs
+++ b/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsTelephoneNumberAttribute.cs
@@ -36,7 +36,10 @@ public class UKGdsTelephoneNumberAttribute : ValidationAttribute
                 // throws if not a possible number somewhere in the world
                 var phoneNumber = phoneNumberUtil.Parse(phoneNumberString, "GB");
                 // does more in depth validation, including if it's a valid UK number
-                isValid = phoneNumberUtil.IsValidNumber(phoneNumber);
+                isValid = phoneNumberUtil.IsValidNumber(phoneNumber)
+                    && phoneNumberUtil.GetRegionCodeForNumber(phoneNumber) == "GB"
+                    // libphonenumber allows some characters that we don't want to allow
+                    && !phoneNumberString.Intersect("!\"£$%^&*={}'@~\\|?/").Any();
             }
             catch (NumberParseException ex)
             {

--- a/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsTelephoneNumberAttribute.cs
+++ b/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsTelephoneNumberAttribute.cs
@@ -28,10 +28,20 @@ public class UKGdsTelephoneNumberAttribute : ValidationAttribute
         if (value != null)
         {
             string phoneNumberString = (string)value;
+            bool isValid = false;
 
             PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.GetInstance();
-            var phoneNumber = phoneNumberUtil.Parse(phoneNumberString, "GB");
-            bool isValid = phoneNumberUtil.IsValidNumber(phoneNumber);
+            try
+            {
+                // throws if not a possible number somewhere in the world
+                var phoneNumber = phoneNumberUtil.Parse(phoneNumberString, "GB");
+                // does more in depth validation, including if it's a valid UK number
+                isValid = phoneNumberUtil.IsValidNumber(phoneNumber);
+            }
+            catch (NumberParseException ex)
+            {
+                // PhoneNumberUtil.Parse calls IsViablePhoneNumber(), which throws a NumberParseException if the number isn't a viable telephone number somewhere in the world
+            }
 
             if (!isValid)
             {

--- a/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsTelephoneNumberAttribute.cs
+++ b/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsTelephoneNumberAttribute.cs
@@ -4,24 +4,12 @@ using PhoneNumbers;
 namespace FamilyHubs.Referral.Core.ValidationAttributes;
 
 /// <summary>
-/// GDS advice:
-/// Allow different formats
-/// -----------------------
-/// Let users enter telephone numbers in whatever format is familiar to them.Allow for additional spaces, hyphens, dashes and brackets, and be able to accommodate country and area codes.
-/// Validate telephone numbers
-/// --------------------------
-/// You should validate telephone numbers so you can let users know if they have entered one incorrectly.Google’s libphonenumber library can validate telephone numbers from most countries.
-///
-/// Notes
-/// -----
-/// This only accepts UK telephone numbers.
-/// Do we allow extensions? e.g. 020 7946 0000 ext 1234 or 020 7946 0000 x1234 or 020 7946 0000 # 1234 etc.
-/// As GDS recommends we validate numbers, we don't allow these examples:
-/// 123 456 7890 until 6pm, then 098 765 4321  
-/// 123 456 7890 or try my mobile on 098 765 4321
-/// 123456 in the week or 567890 at weekends
+/// Validates a UK telephone number.
+/// 
+/// GDS advises that we allow different formats:
+/// Let users enter telephone numbers in whatever format is familiar to them. Allow for additional spaces, hyphens, dashes and brackets, and be able to accommodate country and area codes.
 /// </summary>
-public class UKGdsTelephoneNumberAttribute : ValidationAttribute
+public class UkGdsTelephoneNumberAttribute : ValidationAttribute
 {
     protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
@@ -41,7 +29,7 @@ public class UKGdsTelephoneNumberAttribute : ValidationAttribute
                     // libphonenumber allows some characters that we don't want to allow
                     && !phoneNumberString.Intersect("!\"£$%^&*={}'@~\\|?/").Any();
             }
-            catch (NumberParseException ex)
+            catch (NumberParseException)
             {
                 // PhoneNumberUtil.Parse calls IsViablePhoneNumber(), which throws a NumberParseException if the number isn't a viable telephone number somewhere in the world
             }

--- a/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsTelephoneNumberAttribute.cs
+++ b/src/FamilyHubs.Referral.Core/ValidationAttributes/UKGdsTelephoneNumberAttribute.cs
@@ -1,0 +1,44 @@
+﻿using System.ComponentModel.DataAnnotations;
+using PhoneNumbers;
+
+namespace FamilyHubs.Referral.Core.ValidationAttributes;
+
+/// <summary>
+/// GDS advice:
+/// Allow different formats
+/// -----------------------
+/// Let users enter telephone numbers in whatever format is familiar to them.Allow for additional spaces, hyphens, dashes and brackets, and be able to accommodate country and area codes.
+/// Validate telephone numbers
+/// --------------------------
+/// You should validate telephone numbers so you can let users know if they have entered one incorrectly.Google’s libphonenumber library can validate telephone numbers from most countries.
+///
+/// Notes
+/// -----
+/// This only accepts UK telephone numbers.
+/// Do we allow extensions? e.g. 020 7946 0000 ext 1234 or 020 7946 0000 x1234 or 020 7946 0000 # 1234 etc.
+/// As GDS recommends we validate numbers, we don't allow these examples:
+/// 123 456 7890 until 6pm, then 098 765 4321  
+/// 123 456 7890 or try my mobile on 098 765 4321
+/// 123456 in the week or 567890 at weekends
+/// </summary>
+public class UKGdsTelephoneNumberAttribute : ValidationAttribute
+{
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value != null)
+        {
+            string phoneNumberString = (string)value;
+
+            PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.GetInstance();
+            var phoneNumber = phoneNumberUtil.Parse(phoneNumberString, "GB");
+            bool isValid = phoneNumberUtil.IsValidNumber(phoneNumber);
+
+            if (!isValid)
+            {
+                return new ValidationResult("Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192");
+            }
+        }
+
+        return ValidationResult.Success;
+    }
+}

--- a/src/FamilyHubs.Referral.Infrastructure/DistributedCache/ServiceCollectionExtension.cs
+++ b/src/FamilyHubs.Referral.Infrastructure/DistributedCache/ServiceCollectionExtension.cs
@@ -20,7 +20,6 @@ public static class ServiceCollectionExtension
             options.InstanceName = "ReferralWeb";
         });
 
-        services.AddTransient<ICacheKeys, CacheKeys>();
         services.AddTransient<IConnectionRequestDistributedCache, ConnectionRequestDistributedCache>();
 
         // there's currently only one, so this should be fine

--- a/src/FamilyHubs.Referral.Infrastructure/FamilyHubs.Referral.Infrastructure.csproj
+++ b/src/FamilyHubs.Referral.Infrastructure/FamilyHubs.Referral.Infrastructure.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.5" />
-	  <PackageReference Include="SonarAnalyzer.CSharp" Version="8.55.0.65544">
+	  <PackageReference Include="SonarAnalyzer.CSharp" Version="9.0.0.68202">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/FamilyHubs.Referral.Web/DistributedCache/CacheKeys.cs
+++ b/src/FamilyHubs.Referral.Web/DistributedCache/CacheKeys.cs
@@ -1,8 +1,8 @@
 ﻿using FamilyHubs.Referral.Core.DistributedCache;
-using Microsoft.AspNetCore.Http;
 
-namespace FamilyHubs.Referral.Infrastructure.DistributedCache;
+namespace FamilyHubs.Referral.Web.DistributedCache;
 
+//todo: move this back into infrastructure?
 public class CacheKeys : ICacheKeys
 {
     private readonly string _sessionId;

--- a/src/FamilyHubs.Referral.Web/FamilyHubs.Referral.Web.csproj
+++ b/src/FamilyHubs.Referral.Web/FamilyHubs.Referral.Web.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.55.0.65544">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.0.0.68202">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -25,7 +25,7 @@
                     Yes
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/Consent" asp-route-serviceId="@Model.ServiceId">
+                    <a asp-page="/ProfessionalReferral/Consent" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
                         Change<span class="govuk-visually-hidden"> permission to share details</span>
                     </a>
                 </dd>
@@ -38,7 +38,7 @@
                     @Model.ConnectionRequestModel!.FamilyContactFullName
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/SupportDetails" asp-route-serviceId="@Model.ServiceId">
+                    <a asp-page="/ProfessionalReferral/SupportDetails" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
                         Change<span class="govuk-visually-hidden"> name of contact</span>
                     </a>
                 </dd>
@@ -51,7 +51,7 @@
                     @Model.ConnectionRequestModel!.Reason
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/WhySupport" asp-route-serviceId="@Model.ServiceId">
+                    <a asp-page="/ProfessionalReferral/WhySupport" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
                         Change<span class="govuk-visually-hidden"> reason for request for support</span>
                     </a>
                 </dd>
@@ -98,7 +98,7 @@
                     @Model.ConnectionRequestModel.EmailAddress
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/Email" asp-route-serviceId="@Model.ServiceId">
+                    <a asp-page="/ProfessionalReferral/Email" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
                         Change<span class="govuk-visually-hidden"> email address</span>
                     </a>
                 </dd>
@@ -112,7 +112,7 @@
                     @Model.ConnectionRequestModel.TelephoneNumber
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/Telephone" asp-route-serviceId="@Model.ServiceId">
+                    <a asp-page="/ProfessionalReferral/Telephone" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
                         Change<span class="govuk-visually-hidden"> telephone number</span>
                     </a>
                 </dd>
@@ -126,7 +126,7 @@
                     @Model.ConnectionRequestModel.TextphoneNumber
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/Text" asp-route-serviceId="@Model.ServiceId">
+                    <a asp-page="/ProfessionalReferral/Text" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
                         Change<span class="govuk-visually-hidden"> text telephone number</span>
                     </a>
                 </dd>
@@ -145,7 +145,7 @@
                         Model.ConnectionRequestModel.Postcode)))
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/Letter" asp-route-serviceId="@Model.ServiceId">
+                    <a asp-page="/ProfessionalReferral/Letter" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
                         Change<span class="govuk-visually-hidden"> address</span>
                     </a>
                 </dd>
@@ -159,7 +159,7 @@
                     @Model.ConnectionRequestModel.EngageReason
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/ContactMethods" asp-route-serviceId="@Model.ServiceId">
+                    <a asp-page="/ProfessionalReferral/ContactMethods" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
                         Change<span class="govuk-visually-hidden"> how to engage with the family</span>
                     </a>
                 </dd>

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -85,7 +85,7 @@
                     }
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/ContactMethods" asp-route-serviceId="@Model.ServiceId" asp-route-changing="contact-methods">
+                    <a asp-page="/ProfessionalReferral/ContactDetails" asp-route-serviceId="@Model.ServiceId" asp-route-changing="contact-methods">
                         Change<span class="govuk-visually-hidden"> contact methods</span>
                     </a>
                 </dd>

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -6,7 +6,7 @@
 }
 
 @section Back {
-    <a asp-page="/ProfessionalReferral/ContactMethods" asp-route-serviceId="@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <div class="govuk-grid-row">
@@ -61,8 +61,6 @@
                     Contact methods
                 </dt>
                 <dd class="govuk-summary-list__value">
-                    @*todo: when user changes these, will have to blank any details we're no longer collecting*@
-
                     @{
                         // it's starting to feel like using the enum name (with display attr fallback) would be preferable
                         string[] contactMethodDisplayNames =
@@ -74,7 +72,7 @@
                         };
 
                         List<string> contactMethodsSelected = new List<string>();
-                        for (int contactMethod = 0; contactMethod <= (int) ConnectJourneyPage.LastContactMethod; ++contactMethod)
+                        for (int contactMethod = 0; contactMethod <= (int)ConnectContactDetailsJourneyPage.LastContactMethod; ++contactMethod)
                         {
                             if (Model.ConnectionRequestModel.ContactMethodsSelected[contactMethod])
                             {

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -12,147 +12,143 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                <h1 class="govuk-fieldset__heading">
-                    Check the details you entered before requesting a connection
-                </h1>
-            </legend>
+        <h1 class="govuk-heading-l">
+            Check the details you entered before requesting a connection
+        </h1>
 
-            <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                        Permission to share details
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        Yes
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="#">
-                            Change<span class="govuk-visually-hidden">Change permission to share details.</span>
-                        </a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                        Name of contact
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        @Model.ConnectionRequestModel!.FamilyContactFullName
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="#">
-                            Change<span class="govuk-visually-hidden">Change name of contact.</span>
-                        </a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                        Reason for request for support
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        @Model.ConnectionRequestModel!.Reason
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="#">
-                            Change<span class="govuk-visually-hidden">Change reason for request for support.</span>
-                        </a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                        Contact methods
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        todo
-                        @*                @string.Join(", ", 
-                Model.ConnectionRequestModel.ContactMethodsSelected
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Permission to share details
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    Yes
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">Change permission to share details.</span>
+                    </a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Name of contact
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.ConnectionRequestModel!.FamilyContactFullName
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">Change name of contact.</span>
+                    </a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Reason for request for support
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.ConnectionRequestModel!.Reason
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">Change reason for request for support.</span>
+                    </a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Contact methods
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    todo
+                    @*                @string.Join(", ", 
+            Model.ConnectionRequestModel.ContactMethodsSelected
 *@
-                        @*Email, Phone, Text, Letter*@
-                        @*todo: when user changes these, will have to blank any details we're no longer collecting*@
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="#">
-                            Change<span class="govuk-visually-hidden">Change contact methods.</span>
-                        </a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                        Email
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        @Model.ConnectionRequestModel.EmailAddress
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="#">
-                            Change<span class="govuk-visually-hidden">Change email address.</span>
-                        </a>
-                    </dd>
-                </div>
+                    @*Email, Phone, Text, Letter*@
+                    @*todo: when user changes these, will have to blank any details we're no longer collecting*@
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">Change contact methods.</span>
+                    </a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Email
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.ConnectionRequestModel.EmailAddress
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">Change email address.</span>
+                    </a>
+                </dd>
+            </div>
 
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                        Telephone
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        @Model.ConnectionRequestModel.TelephoneNumber
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="#">
-                            Change<span class="govuk-visually-hidden">Change telephone number.</span>
-                        </a>
-                    </dd>
-                </div>
-  
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                        Text
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        @Model.ConnectionRequestModel.TextphoneNumber
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="#">
-                            Change<span class="govuk-visually-hidden">Change text telephone number.</span>
-                        </a>
-                    </dd>
-                </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Telephone
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.ConnectionRequestModel.TelephoneNumber
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">Change telephone number.</span>
+                    </a>
+                </dd>
+            </div>
 
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                        Address
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        @string.Join("<br>", RemoveEmpty(
-                            Model.ConnectionRequestModel.AddressLine1,
-                            Model.ConnectionRequestModel.AddressLine2,
-                            Model.ConnectionRequestModel.TownOrCity,
-                            Model.ConnectionRequestModel.County,
-                            Model.ConnectionRequestModel.Postcode))
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="#">
-                            Change<span class="govuk-visually-hidden">Change address.</span>
-                        </a>
-                    </dd>
-                </div>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Text
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.ConnectionRequestModel.TextphoneNumber
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">Change text telephone number.</span>
+                    </a>
+                </dd>
+            </div>
 
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">
-                        How to engage with the family
-                    </dt>
-                    <dd class="govuk-summary-list__value">
-                        @Model.ConnectionRequestModel.EngageReason
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="#">
-                            Change<span class="govuk-visually-hidden">Change how to engage with the family.</span>
-                        </a>
-                    </dd>
-                </div>
-            </dl>
-        </fieldset>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    Address
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @string.Join("<br>", RemoveEmpty(
+                        Model.ConnectionRequestModel.AddressLine1,
+                        Model.ConnectionRequestModel.AddressLine2,
+                        Model.ConnectionRequestModel.TownOrCity,
+                        Model.ConnectionRequestModel.County,
+                        Model.ConnectionRequestModel.Postcode))
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">Change address.</span>
+                    </a>
+                </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                    How to engage with the family
+                </dt>
+                <dd class="govuk-summary-list__value">
+                    @Model.ConnectionRequestModel.EngageReason
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="#">
+                        Change<span class="govuk-visually-hidden">Change how to engage with the family.</span>
+                    </a>
+                </dd>
+            </div>
+        </dl>
 
         <h2 class="govuk-heading-m">Now request a connection</h2>
 

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -25,8 +25,8 @@
                     Yes
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
-                        Change<span class="govuk-visually-hidden">Change permission to share details.</span>
+                    <a href="#">
+                        Change<span class="govuk-visually-hidden"> permission to share details</span>
                     </a>
                 </dd>
             </div>
@@ -38,8 +38,8 @@
                     @Model.ConnectionRequestModel!.FamilyContactFullName
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
-                        Change<span class="govuk-visually-hidden">Change name of contact.</span>
+                    <a href="#">
+                        Change<span class="govuk-visually-hidden"> name of contact</span>
                     </a>
                 </dd>
             </div>
@@ -51,8 +51,8 @@
                     @Model.ConnectionRequestModel!.Reason
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
-                        Change<span class="govuk-visually-hidden">Change reason for request for support.</span>
+                    <a href="#">
+                        Change<span class="govuk-visually-hidden"> reason for request for support</span>
                     </a>
                 </dd>
             </div>
@@ -69,8 +69,8 @@
                     @*todo: when user changes these, will have to blank any details we're no longer collecting*@
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
-                        Change<span class="govuk-visually-hidden">Change contact methods.</span>
+                    <a href="#">
+                        Change<span class="govuk-visually-hidden"> contact methods</span>
                     </a>
                 </dd>
             </div>
@@ -82,8 +82,8 @@
                     @Model.ConnectionRequestModel.EmailAddress
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
-                        Change<span class="govuk-visually-hidden">Change email address.</span>
+                    <a href="#">
+                        Change<span class="govuk-visually-hidden"> email address</span>
                     </a>
                 </dd>
             </div>
@@ -96,8 +96,8 @@
                     @Model.ConnectionRequestModel.TelephoneNumber
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
-                        Change<span class="govuk-visually-hidden">Change telephone number.</span>
+                    <a href="#">
+                        Change<span class="govuk-visually-hidden"> telephone number</span>
                     </a>
                 </dd>
             </div>
@@ -110,8 +110,8 @@
                     @Model.ConnectionRequestModel.TextphoneNumber
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
-                        Change<span class="govuk-visually-hidden">Change text telephone number.</span>
+                    <a href="#">
+                        Change<span class="govuk-visually-hidden"> text telephone number</span>
                     </a>
                 </dd>
             </div>
@@ -129,8 +129,8 @@
                         Model.ConnectionRequestModel.Postcode))
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
-                        Change<span class="govuk-visually-hidden">Change address.</span>
+                    <a href="#">
+                        Change<span class="govuk-visually-hidden"> address</span>
                     </a>
                 </dd>
             </div>
@@ -143,8 +143,8 @@
                     @Model.ConnectionRequestModel.EngageReason
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a class="govuk-link" href="#">
-                        Change<span class="govuk-visually-hidden">Change how to engage with the family.</span>
+                    <a href="#">
+                        Change<span class="govuk-visually-hidden"> how to engage with the family</span>
                     </a>
                 </dd>
             </div>

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -25,7 +25,7 @@
                     Yes
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a href="#">
+                    <a asp-page="/ProfessionalReferral/Consent" asp-route-serviceId="@Model.ServiceId">
                         Change<span class="govuk-visually-hidden"> permission to share details</span>
                     </a>
                 </dd>
@@ -38,7 +38,7 @@
                     @Model.ConnectionRequestModel!.FamilyContactFullName
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a href="#">
+                    <a asp-page="/ProfessionalReferral/SupportDetails" asp-route-serviceId="@Model.ServiceId">
                         Change<span class="govuk-visually-hidden"> name of contact</span>
                     </a>
                 </dd>
@@ -51,7 +51,7 @@
                     @Model.ConnectionRequestModel!.Reason
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a href="#">
+                    <a asp-page="/ProfessionalReferral/WhySupport" asp-route-serviceId="@Model.ServiceId">
                         Change<span class="govuk-visually-hidden"> reason for request for support</span>
                     </a>
                 </dd>
@@ -69,7 +69,7 @@
                     @*todo: when user changes these, will have to blank any details we're no longer collecting*@
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a href="#">
+                    <a asp-page="/ProfessionalReferral/ContactMethods" asp-route-serviceId="@Model.ServiceId">
                         Change<span class="govuk-visually-hidden"> contact methods</span>
                     </a>
                 </dd>
@@ -82,7 +82,7 @@
                     @Model.ConnectionRequestModel.EmailAddress
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a href="#">
+                    <a asp-page="/ProfessionalReferral/Email" asp-route-serviceId="@Model.ServiceId">
                         Change<span class="govuk-visually-hidden"> email address</span>
                     </a>
                 </dd>
@@ -96,7 +96,7 @@
                     @Model.ConnectionRequestModel.TelephoneNumber
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a href="#">
+                    <a asp-page="/ProfessionalReferral/Telephone" asp-route-serviceId="@Model.ServiceId">
                         Change<span class="govuk-visually-hidden"> telephone number</span>
                     </a>
                 </dd>
@@ -110,7 +110,7 @@
                     @Model.ConnectionRequestModel.TextphoneNumber
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a href="#">
+                    <a asp-page="/ProfessionalReferral/Text" asp-route-serviceId="@Model.ServiceId">
                         Change<span class="govuk-visually-hidden"> text telephone number</span>
                     </a>
                 </dd>
@@ -129,7 +129,7 @@
                         Model.ConnectionRequestModel.Postcode))
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a href="#">
+                    <a asp-page="/ProfessionalReferral/Letter" asp-route-serviceId="@Model.ServiceId">
                         Change<span class="govuk-visually-hidden"> address</span>
                     </a>
                 </dd>
@@ -143,7 +143,7 @@
                     @Model.ConnectionRequestModel.EngageReason
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a href="#">
+                    <a asp-page="/ProfessionalReferral/ContactMethods" asp-route-serviceId="@Model.ServiceId">
                         Change<span class="govuk-visually-hidden"> how to engage with the family</span>
                     </a>
                 </dd>

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -90,49 +90,62 @@
                     </a>
                 </dd>
             </div>
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                    Email
-                </dt>
-                <dd class="govuk-summary-list__value">
-                    @Model.ConnectionRequestModel.EmailAddress
-                </dd>
-                <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/Email" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
-                        Change<span class="govuk-visually-hidden"> email address</span>
-                    </a>
-                </dd>
-            </div>
 
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                    Telephone
-                </dt>
-                <dd class="govuk-summary-list__value">
-                    @Model.ConnectionRequestModel.TelephoneNumber
-                </dd>
-                <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/Telephone" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
-                        Change<span class="govuk-visually-hidden"> telephone number</span>
-                    </a>
-                </dd>
-            </div>
+            @if (Model.ConnectionRequestModel.EmailAddress != null)
+            {
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Email
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @Model.ConnectionRequestModel.EmailAddress
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a asp-page="/ProfessionalReferral/Email" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
+                            Change<span class="govuk-visually-hidden"> email address</span>
+                        </a>
+                    </dd>
+                </div>
+            }
 
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                    Text
-                </dt>
-                <dd class="govuk-summary-list__value">
-                    @Model.ConnectionRequestModel.TextphoneNumber
-                </dd>
-                <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/Text" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
-                        Change<span class="govuk-visually-hidden"> text telephone number</span>
-                    </a>
-                </dd>
-            </div>
-
-            <div class="govuk-summary-list__row">
+            @if (Model.ConnectionRequestModel.TelephoneNumber != null)
+            {
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Telephone
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @Model.ConnectionRequestModel.TelephoneNumber
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a asp-page="/ProfessionalReferral/Telephone" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
+                            Change<span class="govuk-visually-hidden"> telephone number</span>
+                        </a>
+                    </dd>
+                </div>
+            }
+            
+            @if (Model.ConnectionRequestModel.TextphoneNumber != null)
+            {
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Text
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @Model.ConnectionRequestModel.TextphoneNumber
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a asp-page="/ProfessionalReferral/Text" asp-route-serviceId="@Model.ServiceId" asp-route-changing="page">
+                            Change<span class="govuk-visually-hidden"> text telephone number</span>
+                        </a>
+                    </dd>
+                </div>
+            }
+            
+            @* AddressLine1 is a mandatory field, so we use it as a proxy for the whole address *@
+            @if (Model.ConnectionRequestModel.AddressLine1 != null)
+            {
+                <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
                     Address
                 </dt>
@@ -150,6 +163,7 @@
                     </a>
                 </dd>
             </div>
+            }
 
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -1,0 +1,173 @@
+﻿@page
+@model FamilyHubs.Referral.Web.Pages.ProfessionalReferral.CheckDetailsModel
+
+@{
+    ViewData["Title"] = "Check the details you entered before requesting a connection";
+}
+
+@section Back {
+    <a asp-page="/ProfessionalReferral/ContactMethods" asp-route-serviceId="@Model.ServiceId" class="govuk-back-link">Back</a>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h1 class="govuk-fieldset__heading">
+                    Check the details you entered before requesting a connection
+                </h1>
+            </legend>
+
+            <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Permission to share details
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        Yes
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Change<span class="govuk-visually-hidden">Change permission to share details.</span>
+                        </a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Name of contact
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @Model.ConnectionRequestModel!.FamilyContactFullName
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Change<span class="govuk-visually-hidden">Change name of contact.</span>
+                        </a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Reason for request for support
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @Model.ConnectionRequestModel!.Reason
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Change<span class="govuk-visually-hidden">Change reason for request for support.</span>
+                        </a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Contact methods
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        todo
+                        @*                @string.Join(", ", 
+                Model.ConnectionRequestModel.ContactMethodsSelected
+*@
+                        @*Email, Phone, Text, Letter*@
+                        @*todo: when user changes these, will have to blank any details we're no longer collecting*@
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Change<span class="govuk-visually-hidden">Change contact methods.</span>
+                        </a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Email
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @Model.ConnectionRequestModel.EmailAddress
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Change<span class="govuk-visually-hidden">Change email address.</span>
+                        </a>
+                    </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Telephone
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @Model.ConnectionRequestModel.TelephoneNumber
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Change<span class="govuk-visually-hidden">Change telephone number.</span>
+                        </a>
+                    </dd>
+                </div>
+  
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Text
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @Model.ConnectionRequestModel.TextphoneNumber
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Change<span class="govuk-visually-hidden">Change text telephone number.</span>
+                        </a>
+                    </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Address
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @string.Join("<br>", RemoveEmpty(
+                            Model.ConnectionRequestModel.AddressLine1,
+                            Model.ConnectionRequestModel.AddressLine2,
+                            Model.ConnectionRequestModel.TownOrCity,
+                            Model.ConnectionRequestModel.County,
+                            Model.ConnectionRequestModel.Postcode))
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Change<span class="govuk-visually-hidden">Change address.</span>
+                        </a>
+                    </dd>
+                </div>
+
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        How to engage with the family
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        @Model.ConnectionRequestModel.EngageReason
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Change<span class="govuk-visually-hidden">Change how to engage with the family.</span>
+                        </a>
+                    </dd>
+                </div>
+            </dl>
+        </fieldset>
+
+        <h2 class="govuk-heading-m">Now request a connection</h2>
+
+        <form method="post">
+            <button type="submit" class="govuk-button" data-module="govuk-button">
+                Confirm details and send request
+            </button>
+        </form>
+    </div>
+</div>
+
+@functions
+{
+    private static IEnumerable<string> RemoveEmpty(params string?[] list)
+    {
+        return list.Where(x => !string.IsNullOrWhiteSpace(x))!;
+    }
+}

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -85,7 +85,7 @@
                     }
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                    <a asp-page="/ProfessionalReferral/ContactMethods" asp-route-serviceId="@Model.ServiceId">
+                    <a asp-page="/ProfessionalReferral/ContactMethods" asp-route-serviceId="@Model.ServiceId" asp-route-changing="contact-methods">
                         Change<span class="govuk-visually-hidden"> contact methods</span>
                     </a>
                 </dd>

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -137,12 +137,12 @@
                     Address
                 </dt>
                 <dd class="govuk-summary-list__value">
-                    @string.Join("<br>", RemoveEmpty(
+                    @Html.Raw(string.Join("<br>", RemoveEmpty(
                         Model.ConnectionRequestModel.AddressLine1,
                         Model.ConnectionRequestModel.AddressLine2,
                         Model.ConnectionRequestModel.TownOrCity,
                         Model.ConnectionRequestModel.County,
-                        Model.ConnectionRequestModel.Postcode))
+                        Model.ConnectionRequestModel.Postcode)))
                 </dd>
                 <dd class="govuk-summary-list__actions">
                     <a asp-page="/ProfessionalReferral/Letter" asp-route-serviceId="@Model.ServiceId">

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml
@@ -61,12 +61,28 @@
                     Contact methods
                 </dt>
                 <dd class="govuk-summary-list__value">
-                    todo
-                    @*                @string.Join(", ", 
-            Model.ConnectionRequestModel.ContactMethodsSelected
-*@
-                    @*Email, Phone, Text, Letter*@
                     @*todo: when user changes these, will have to blank any details we're no longer collecting*@
+
+                    @{
+                        // it's starting to feel like using the enum name (with display attr fallback) would be preferable
+                        string[] contactMethodDisplayNames =
+                        {
+                            "Email",
+                            "Telephone",
+                            "Text message",
+                            "Letter"
+                        };
+
+                        List<string> contactMethodsSelected = new List<string>();
+                        for (int contactMethod = 0; contactMethod <= (int) ConnectJourneyPage.LastContactMethod; ++contactMethod)
+                        {
+                            if (Model.ConnectionRequestModel.ContactMethodsSelected[contactMethod])
+                            {
+                                contactMethodsSelected.Add(contactMethodDisplayNames[contactMethod]);
+                            }
+                        }
+                        @string.Join(", ", contactMethodsSelected)
+                    }
                 </dd>
                 <dd class="govuk-summary-list__actions">
                     <a asp-page="/ProfessionalReferral/ContactMethods" asp-route-serviceId="@Model.ServiceId">

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml.cs
@@ -2,25 +2,60 @@ using FamilyHubs.Referral.Core.DistributedCache;
 using FamilyHubs.Referral.Core.Models;
 using FamilyHubs.Referral.Web.Pages.Shared;
 
-namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral
+namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral;
+
+public class CheckDetailsModel : ProfessionalReferralSessionModel
 {
-    public class CheckDetailsModel : ProfessionalReferralSessionModel
+    public ConnectionRequestModel? ConnectionRequestModel { get; set; }
+
+    public CheckDetailsModel(IConnectionRequestDistributedCache connectionRequestCache)
+        : base(ConnectJourneyPage.CheckDetails, connectionRequestCache)
     {
-        public ConnectionRequestModel? ConnectionRequestModel { get; set; }
+    }
 
-        public CheckDetailsModel(IConnectionRequestDistributedCache connectionRequestCache)
-            : base(ConnectJourneyPage.CheckDetails, connectionRequestCache)
+    protected override void OnGetWithModel(ConnectionRequestModel model)
+    {
+        // do this now, so we don't display any previously entered contact details that are no longer selected
+        // but don't remove them from the session yet, in case the user goes back to change the contact details
+        // we'll remove them from the session when the user submits the form
+        RemoveNonSelectedContactDetails(model);
+
+        ConnectionRequestModel = model;
+    }
+
+    private static void RemoveNonSelectedContactDetails(ConnectionRequestModel model)
+    {
+        // remove any previously entered contact details that are no longer selected
+        //todo: can we do this generically?
+        if (!model.ContactMethodsSelected[(int) ConnectContactDetailsJourneyPage.Email])
         {
+            model.EmailAddress = null;
         }
 
-        protected override void OnGetWithModel(ConnectionRequestModel model)
+        if (!model.ContactMethodsSelected[(int) ConnectContactDetailsJourneyPage.Telephone])
         {
-            ConnectionRequestModel = model;
+            model.TelephoneNumber = null;
         }
 
-        protected override string? OnPostWithModel(ConnectionRequestModel model)
+        if (!model.ContactMethodsSelected[(int) ConnectContactDetailsJourneyPage.Textphone])
         {
-            return "Confirmation";
+            model.TextphoneNumber = null;
         }
+
+        if (!model.ContactMethodsSelected[(int) ConnectContactDetailsJourneyPage.Letter])
+        {
+            model.AddressLine1 = null;
+            model.AddressLine2 = null;
+            model.TownOrCity = null;
+            model.County = null;
+            model.Postcode = null;
+        }
+    }
+
+    protected override string? OnPostWithModel(ConnectionRequestModel model)
+    {
+        RemoveNonSelectedContactDetails(model);
+
+        return "Confirmation";
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml.cs
@@ -9,7 +9,7 @@ namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral
         public ConnectionRequestModel? ConnectionRequestModel { get; set; }
 
         public CheckDetailsModel(IConnectionRequestDistributedCache connectionRequestCache)
-            : base(connectionRequestCache)
+            : base(ConnectJourneyPage.CheckDetails, connectionRequestCache)
         {
         }
 

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/CheckDetails.cshtml.cs
@@ -1,0 +1,26 @@
+using FamilyHubs.Referral.Core.DistributedCache;
+using FamilyHubs.Referral.Core.Models;
+using FamilyHubs.Referral.Web.Pages.Shared;
+
+namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral
+{
+    public class CheckDetailsModel : ProfessionalReferralSessionModel
+    {
+        public ConnectionRequestModel? ConnectionRequestModel { get; set; }
+
+        public CheckDetailsModel(IConnectionRequestDistributedCache connectionRequestCache)
+            : base(connectionRequestCache)
+        {
+        }
+
+        protected override void OnGetWithModel(ConnectionRequestModel model)
+        {
+            ConnectionRequestModel = model;
+        }
+
+        protected override string? OnPostWithModel(ConnectionRequestModel model)
+        {
+            return "Confirmation";
+        }
+    }
+}

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Consent.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Consent.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section Back {
-    <a href="/ProfessionalReferral/Safeguarding?serviceId=@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <div class="govuk-grid-row">

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Consent.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Consent.cshtml.cs
@@ -11,6 +11,10 @@ public class ConsentModel : ProfessionalReferralModel
     [BindProperty]
     public bool ValidationValid { get; set; } = true;
 
+    public ConsentModel() : base(ConnectJourneyPage.Consent)
+    {
+    }
+
     protected override Task<IActionResult> OnSafePostAsync()
     {
         return Task.FromResult(OnSafePost());

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Consent.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Consent.cshtml.cs
@@ -26,9 +26,9 @@ public class ConsentModel : ProfessionalReferralModel
 
         if (string.Compare(Consent, "yes", StringComparison.OrdinalIgnoreCase) == 0)
         {
-            return RedirectToProfessionalReferralPage("SupportDetails");
+            return NextPage("SupportDetails");
         }
 
-        return RedirectToPage("/ProfessionalReferral/ConsentShutter");
+        return RedirectToProfessionalReferralPage("ConsentShutter");
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ConsentShutter.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ConsentShutter.cshtml
@@ -1,5 +1,4 @@
 ﻿@page
-@model FamilyHubs.Referral.Web.Pages.ProfessionalReferral.ConsentShutterModel
 @{
     ViewData["Title"] = "Cannot connect family to service";
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ConsentShutter.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ConsentShutter.cshtml.cs
@@ -1,9 +1,0 @@
-using Microsoft.AspNetCore.Mvc.RazorPages;
-
-namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral
-{
-    public class ConsentShutterModel : PageModel
-    {
-        
-    }
-}

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactDetails.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section Back {
-    <a asp-page="/ProfessionalReferral/WhySupport" asp-route-serviceId="@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <div class="govuk-grid-row">
@@ -57,7 +57,7 @@
                                 "Letter"
                             };
 
-                            for (int contactMethod = 0; contactMethod <= (int) ConnectJourneyPage.LastContactMethod; ++contactMethod)
+                            for (int contactMethod = 0; contactMethod <= (int)ConnectContactDetailsJourneyPage.LastContactMethod; ++contactMethod)
                             {
                                 // work around captured variable being modified in outside scope
                                 int capturedContactMethod = contactMethod;

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactDetails.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactDetails.cshtml.cs
@@ -32,6 +32,32 @@ public class ContactDetailsModel : ProfessionalReferralSessionModel
 
         model.ContactMethodsSelected = ContactMethods;
 
+        // if the user has come from the check details page,
+        //if (Flow == JourneyFlow.ChangingContactMethods)
+        //{
+        // we need to remove any previous contact details that are no longer selected
+        //todo: can we do this generically?
+        if (!ContactMethods[(int) ConnectJourneyPage.Email])
+        {
+            model.EmailAddress = null;
+        }
+        if (!ContactMethods[(int)ConnectJourneyPage.Telephone])
+        {
+            model.TelephoneNumber = null;
+        }
+        if (!ContactMethods[(int)ConnectJourneyPage.Textphone])
+        {
+            model.TextphoneNumber = null;
+        }
+        if (!ContactMethods[(int)ConnectJourneyPage.Letter])
+        {
+            model.AddressLine1 = null;
+            model.AddressLine2 = null;
+            model.TownOrCity = null;
+            model.County = null;
+            model.Postcode = null;
+        }
+        //}
         return FirstContactMethodPage(model.ContactMethodsSelected);
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactDetails.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactDetails.cshtml.cs
@@ -33,29 +33,6 @@ public class ContactDetailsModel : ProfessionalReferralSessionModel
 
         model.ContactMethodsSelected = ContactMethods;
 
-        // we need to remove any previous contact details that are no longer selected
-        //todo: can we do this generically?
-        if (!ContactMethods[(int)ConnectContactDetailsJourneyPage.Email])
-        {
-            model.EmailAddress = null;
-        }
-        if (!ContactMethods[(int)ConnectContactDetailsJourneyPage.Telephone])
-        {
-            model.TelephoneNumber = null;
-        }
-        if (!ContactMethods[(int)ConnectContactDetailsJourneyPage.Textphone])
-        {
-            model.TextphoneNumber = null;
-        }
-        if (!ContactMethods[(int)ConnectContactDetailsJourneyPage.Letter])
-        {
-            model.AddressLine1 = null;
-            model.AddressLine2 = null;
-            model.TownOrCity = null;
-            model.County = null;
-            model.Postcode = null;
-        }
-
         return FirstContactMethodPage(model.ContactMethodsSelected);
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactDetails.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactDetails.cshtml.cs
@@ -10,9 +10,10 @@ public class ContactDetailsModel : ProfessionalReferralSessionModel
     public string? FullName { get; set; }
 
     [BindProperty]
-    public bool[] ContactMethods { get; set; } = new bool[(int)ConnectJourneyPage.LastContactMethod+1];
+    public bool[] ContactMethods { get; set; } = new bool[(int)ConnectContactDetailsJourneyPage.LastContactMethod+1];
 
-    public ContactDetailsModel(IConnectionRequestDistributedCache connectionRequestCache) : base(connectionRequestCache)
+    public ContactDetailsModel(IConnectionRequestDistributedCache connectionRequestCache)
+        : base(ConnectJourneyPage.ContactDetails, connectionRequestCache)
     {
     }
 
@@ -32,24 +33,21 @@ public class ContactDetailsModel : ProfessionalReferralSessionModel
 
         model.ContactMethodsSelected = ContactMethods;
 
-        // if the user has come from the check details page,
-        //if (Flow == JourneyFlow.ChangingContactMethods)
-        //{
         // we need to remove any previous contact details that are no longer selected
         //todo: can we do this generically?
-        if (!ContactMethods[(int) ConnectJourneyPage.Email])
+        if (!ContactMethods[(int)ConnectContactDetailsJourneyPage.Email])
         {
             model.EmailAddress = null;
         }
-        if (!ContactMethods[(int)ConnectJourneyPage.Telephone])
+        if (!ContactMethods[(int)ConnectContactDetailsJourneyPage.Telephone])
         {
             model.TelephoneNumber = null;
         }
-        if (!ContactMethods[(int)ConnectJourneyPage.Textphone])
+        if (!ContactMethods[(int)ConnectContactDetailsJourneyPage.Textphone])
         {
             model.TextphoneNumber = null;
         }
-        if (!ContactMethods[(int)ConnectJourneyPage.Letter])
+        if (!ContactMethods[(int)ConnectContactDetailsJourneyPage.Letter])
         {
             model.AddressLine1 = null;
             model.AddressLine2 = null;
@@ -57,7 +55,7 @@ public class ContactDetailsModel : ProfessionalReferralSessionModel
             model.County = null;
             model.Postcode = null;
         }
-        //}
+
         return FirstContactMethodPage(model.ContactMethodsSelected);
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactMethods.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactMethods.cshtml
@@ -6,7 +6,7 @@
 }
 
 @section Back {
-    <a asp-page="@Model.BackUrl" asp-route-serviceId="@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <partial name="/Pages/Shared/_TellTheServicePage.cshtml" model="Model"/>

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactMethods.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactMethods.cshtml.cs
@@ -34,7 +34,7 @@ public class ContactMethodsModel : ProfessionalReferralSessionModel, ITellTheSer
         if (string.IsNullOrEmpty(TextAreaValue))
         {
             SetPageProperties(model);
-            TextAreaValidationErrorMessage = "Enter details about the family";
+            TextAreaValidationErrorMessage = "Enter how best to engage with this family";
             return null;
         }
 

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactMethods.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactMethods.cshtml.cs
@@ -51,6 +51,7 @@ public class ContactMethodsModel : ProfessionalReferralSessionModel, ITellTheSer
         //todo: use next page
         return "CheckDetails";
     }
+
     private void SetPageProperties(ConnectionRequestModel model)
     {
         BackUrl = PreviousPage(ConnectJourneyPage.ContactMethods, model.ContactMethodsSelected);

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactMethods.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactMethods.cshtml.cs
@@ -14,10 +14,9 @@ public class ContactMethodsModel : ProfessionalReferralSessionModel, ITellTheSer
     public string? TextAreaValue { get; set; }
 
     public string? TextAreaValidationErrorMessage { get; set; }
-    public string? BackUrl { get; set; }
 
     public ContactMethodsModel(IConnectionRequestDistributedCache connectionRequestCache)
-        : base(connectionRequestCache)
+        : base(ConnectJourneyPage.ContactMethods, connectionRequestCache)
     {
     }
 
@@ -54,6 +53,6 @@ public class ContactMethodsModel : ProfessionalReferralSessionModel, ITellTheSer
 
     private void SetPageProperties(ConnectionRequestModel model)
     {
-        BackUrl = PreviousPage(ConnectJourneyPage.ContactMethods, model.ContactMethodsSelected);
+        BackUrl = GenerateBackUrl(ConnectContactDetailsJourneyPage.ContactMethods, model.ContactMethodsSelected);
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Email.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Email.cshtml
@@ -5,8 +5,7 @@
 }
 
 @section Back {
-    @*todo: use standard BackUrl pattern for consistency? can the back section be moved into the partial?*@
-    <a asp-page="/ProfessionalReferral/ContactDetails" asp-route-serviceId="@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <partial name="_SingleTextboxPage" for="@Model" />

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Email.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Email.cshtml.cs
@@ -21,7 +21,7 @@ public class EmailModel : ProfessionalReferralSessionModel, ISingleEmailTextboxP
     public string? TextBoxValue { get; set; }
 
     public EmailModel(IConnectionRequestDistributedCache connectionRequestCache)
-        : base(connectionRequestCache)
+        : base(ConnectJourneyPage.Email, connectionRequestCache)
     {
     }
 
@@ -47,11 +47,12 @@ public class EmailModel : ProfessionalReferralSessionModel, ISingleEmailTextboxP
 
         model.EmailAddress = TextBoxValue;
 
-        return NextPage(ConnectJourneyPage.Email, model.ContactMethodsSelected);
+        return NextPage(ConnectContactDetailsJourneyPage.Email, model.ContactMethodsSelected);
     }
 
     private void SetPageProperties(ConnectionRequestModel model)
     {
         HeadingText = $"What is the email address for {model.FamilyContactFullName}?";
+        BackUrl = GenerateBackUrl(ConnectContactDetailsJourneyPage.Email, model.ContactMethodsSelected);
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Letter.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Letter.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section Back {
-    <a asp-page="@Model.BackUrl" asp-route-serviceId="@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <div class="govuk-grid-row">

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Letter.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Letter.cshtml.cs
@@ -26,7 +26,7 @@ public class LetterModel : ProfessionalReferralSessionModel
     public string? County { get; set; } = "";
 
     [BindProperty]
-    [Required(ErrorMessage = "You must enter a postcodeB")]
+    [Required(ErrorMessage = "You must enter a postcode")]
     [UkGdsPostcode]
     public string? Postcode { get; set; } = "";
 

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Letter.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Letter.cshtml.cs
@@ -31,12 +31,11 @@ public class LetterModel : ProfessionalReferralSessionModel
     public string? Postcode { get; set; } = "";
 
     public string HeadingText { get; set; } = "";
-    public string? BackUrl { get; set; }
 
     public Error[]? Errors { get; set; }
 
     public LetterModel(IConnectionRequestDistributedCache connectionRequestCache)
-        : base(connectionRequestCache)
+        : base(ConnectJourneyPage.Letter, connectionRequestCache)
     {
     }
 
@@ -77,12 +76,12 @@ public class LetterModel : ProfessionalReferralSessionModel
         model.County = County;
         model.Postcode = UKGdsPostcodeAttribute.SanitisePostcode(Postcode!);
 
-        return NextPage(ConnectJourneyPage.Letter, model.ContactMethodsSelected);
+        return NextPage(ConnectContactDetailsJourneyPage.Letter, model.ContactMethodsSelected);
     }
 
     private void SetPageProperties(ConnectionRequestModel model)
     {
         HeadingText = $"What is the address for {model.FamilyContactFullName}?";
-        BackUrl = PreviousPage(ConnectJourneyPage.Letter, model.ContactMethodsSelected);
+        BackUrl = GenerateBackUrl(ConnectContactDetailsJourneyPage.Letter, model.ContactMethodsSelected);
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Letter.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Letter.cshtml.cs
@@ -27,7 +27,7 @@ public class LetterModel : ProfessionalReferralSessionModel
 
     [BindProperty]
     [Required(ErrorMessage = "You must enter a postcodeB")]
-    [UKGdsPostcode]
+    [UkGdsPostcode]
     public string? Postcode { get; set; } = "";
 
     public string HeadingText { get; set; } = "";
@@ -74,7 +74,7 @@ public class LetterModel : ProfessionalReferralSessionModel
         model.AddressLine2 = AddressLine2;
         model.TownOrCity = TownOrCity;
         model.County = County;
-        model.Postcode = UKGdsPostcodeAttribute.SanitisePostcode(Postcode!);
+        model.Postcode = UkGdsPostcodeAttribute.SanitisePostcode(Postcode!);
 
         return NextPage(ConnectContactDetailsJourneyPage.Letter, model.ContactMethodsSelected);
     }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Letter.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Letter.cshtml.cs
@@ -12,21 +12,21 @@ public class LetterModel : ProfessionalReferralSessionModel
 {
     //todo: consistency with nullable
     [BindProperty]
-    [Required(ErrorMessage = "You must enter an address.")]
+    [Required(ErrorMessage = "You must enter an address")]
     public string? AddressLine1 { get; set; } = "";
 
     [BindProperty]
     public string? AddressLine2 { get; set; } = "";
 
     [BindProperty]
-    [Required(ErrorMessage = "You must enter a town or city.")]
+    [Required(ErrorMessage = "You must enter a town or city")]
     public string? TownOrCity { get; set; } = "";
 
     [BindProperty]
     public string? County { get; set; } = "";
 
     [BindProperty]
-    [Required(ErrorMessage = "You must enter a postcode.")]
+    [Required(ErrorMessage = "You must enter a postcodeB")]
     [UKGdsPostcode]
     public string? Postcode { get; set; } = "";
 

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Safeguarding.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Safeguarding.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section Back {
-    <a href="/ProfessionalReferral/LocalOfferDetail/?serviceId=@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <div class="govuk-grid-row">

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/SupportDetails.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/SupportDetails.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section Back {
-    <a asp-page="/ProfessionalReferral/Consent" asp-route-serviceId="@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <partial name="_SingleTextboxPage" for="@Model" />

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/SupportDetails.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/SupportDetails.cshtml.cs
@@ -65,6 +65,6 @@ public class SupportDetailsModel : ProfessionalReferralModel, ISingleTextboxPage
         model.FamilyContactFullName = TextBoxValue;
         await _connectionRequestDistributedCache.SetAsync(model);
 
-        return RedirectToProfessionalReferralPage("WhySupport");
+        return NextPage("WhySupport");
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/SupportDetails.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/SupportDetails.cshtml.cs
@@ -23,6 +23,7 @@ public class SupportDetailsModel : ProfessionalReferralModel, ISingleTextboxPage
     public string? TextBoxValue { get; set; }
 
     public SupportDetailsModel(IConnectionRequestDistributedCache connectionRequestDistributedCache)
+        : base(ConnectJourneyPage.SupportDetails)
     {
         _connectionRequestDistributedCache = connectionRequestDistributedCache;
     }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Telephone.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Telephone.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section Back {
-    <a asp-page="@Model.BackUrl" asp-route-serviceId="@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <partial name="_SingleTextboxPage" for="@Model" />

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Telephone.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Telephone.cshtml.cs
@@ -17,7 +17,7 @@ public class TelephoneModel : ProfessionalReferralSessionModel, ISingleTelephone
     public string ErrorText { get; set; } = "";
 
     [Required(ErrorMessage = "Enter a UK telephone number", AllowEmptyStrings = false)]
-    [UKGdsTelephoneNumber]
+    [UkGdsTelephoneNumber]
     [BindProperty]
     public string? TextBoxValue { get; set; }
 

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Telephone.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Telephone.cshtml.cs
@@ -8,7 +8,6 @@ using FamilyHubs.Referral.Core.ValidationAttributes;
 
 namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral;
 
-//todo: check details -> change contact details -> back -> goes to contact details, not check details
 public class TelephoneModel : ProfessionalReferralSessionModel, ISingleTelephoneTextboxPageModel
 {
     public string HeadingText { get; set; } = "";

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Telephone.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Telephone.cshtml.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using FamilyHubs.Referral.Web.Pages.Shared;
 using FamilyHubs.Referral.Core.DistributedCache;
 using FamilyHubs.Referral.Web.Models;
+using FamilyHubs.Referral.Core.ValidationAttributes;
 
 namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral;
 
@@ -16,7 +17,7 @@ public class TelephoneModel : ProfessionalReferralSessionModel, ISingleTelephone
     public string ErrorText { get; set; } = "";
 
     [Required(ErrorMessage = "Enter a UK telephone number", AllowEmptyStrings = false)]
-    [Phone(ErrorMessage = "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192")]
+    [UKGdsTelephoneNumber]
     [BindProperty]
     public string? TextBoxValue { get; set; }
 

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Telephone.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Telephone.cshtml.cs
@@ -7,13 +7,13 @@ using FamilyHubs.Referral.Web.Models;
 
 namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral;
 
+//todo: check details -> change contact details -> back -> goes to contact details, not check details
 public class TelephoneModel : ProfessionalReferralSessionModel, ISingleTelephoneTextboxPageModel
 {
     public string HeadingText { get; set; } = "";
     public string? HintText { get; set; }
     public string TextBoxLabel { get; set; } = "UK telephone number";
     public string ErrorText { get; set; } = "";
-    public string? BackUrl { get; set; }
 
     [Required(ErrorMessage = "Enter a UK telephone number", AllowEmptyStrings = false)]
     [Phone(ErrorMessage = "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192")]
@@ -21,7 +21,7 @@ public class TelephoneModel : ProfessionalReferralSessionModel, ISingleTelephone
     public string? TextBoxValue { get; set; }
 
     public TelephoneModel(IConnectionRequestDistributedCache connectionRequestCache)
-        : base(connectionRequestCache)
+        : base(ConnectJourneyPage.Telephone, connectionRequestCache)
     {
     }
 
@@ -48,12 +48,12 @@ public class TelephoneModel : ProfessionalReferralSessionModel, ISingleTelephone
 
         model.TelephoneNumber = TextBoxValue;
 
-        return NextPage(ConnectJourneyPage.Telephone, model.ContactMethodsSelected);
+        return NextPage(ConnectContactDetailsJourneyPage.Telephone, model.ContactMethodsSelected);
     }
 
     private void SetPageProperties(ConnectionRequestModel model)
     {
         HeadingText = $"What telephone number should the service use to call {model.FamilyContactFullName}?";
-        BackUrl = PreviousPage(ConnectJourneyPage.Telephone, model.ContactMethodsSelected);
+        BackUrl = GenerateBackUrl(ConnectContactDetailsJourneyPage.Telephone, model.ContactMethodsSelected);
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section Back {
-    <a asp-page="@Model.BackUrl" asp-route-serviceId="@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <partial name="_SingleTextboxPage" for="@Model" />

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using FamilyHubs.Referral.Web.Pages.Shared;
 using FamilyHubs.Referral.Core.DistributedCache;
 using FamilyHubs.Referral.Web.Models;
+using FamilyHubs.Referral.Core.ValidationAttributes;
 
 namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral;
 //todo: fix check details -> change contact methods change selection e.g. from text to phone, continue, then back and back again to check details & previous captured text has now been deleted
@@ -17,7 +18,7 @@ public class TextModel : ProfessionalReferralSessionModel, ISingleTelephoneTextb
     public string ErrorText { get; set; } = "";
 
     [Required(ErrorMessage = "Enter a UK telephone number", AllowEmptyStrings = false)]
-    [Phone(ErrorMessage = "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192")]
+    [UKGdsTelephoneNumber]
     [BindProperty]
     public string? TextBoxValue { get; set; }
 

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml.cs
@@ -7,9 +7,7 @@ using FamilyHubs.Referral.Web.Models;
 using FamilyHubs.Referral.Core.ValidationAttributes;
 
 namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral;
-//todo: fix check details -> change contact methods change selection e.g. from text to phone, continue, then back and back again to check details & previous captured text has now been deleted
-// need to clear not selected, either on post of last contact details page, or on get of check details page
-// will mean if you eg. select phone, enter phone, go back, select text, enter text, got back, select phone again and it will have remembered the original phone, but think that's ok
+
 public class TextModel : ProfessionalReferralSessionModel, ISingleTelephoneTextboxPageModel
 {
     public string HeadingText { get; set; } = "";

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml.cs
@@ -18,7 +18,7 @@ public class TextModel : ProfessionalReferralSessionModel, ISingleTelephoneTextb
     public string ErrorText { get; set; } = "";
 
     [Required(ErrorMessage = "Enter a UK telephone number", AllowEmptyStrings = false)]
-    [UKGdsTelephoneNumber]
+    [UkGdsTelephoneNumber]
     [BindProperty]
     public string? TextBoxValue { get; set; }
 

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml.cs
@@ -13,7 +13,6 @@ public class TextModel : ProfessionalReferralSessionModel, ISingleTelephoneTextb
     public string? HintText { get; set; }
     public string TextBoxLabel { get; set; } = "UK telephone number";
     public string ErrorText { get; set; } = "";
-    public string? BackUrl { get; set; }
 
     [Required(ErrorMessage = "Enter a UK telephone number", AllowEmptyStrings = false)]
     [Phone(ErrorMessage = "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192")]
@@ -21,7 +20,7 @@ public class TextModel : ProfessionalReferralSessionModel, ISingleTelephoneTextb
     public string? TextBoxValue { get; set; }
 
     public TextModel(IConnectionRequestDistributedCache connectionRequestCache)
-        : base(connectionRequestCache)
+        : base(ConnectJourneyPage.Text, connectionRequestCache)
     {
     }
 
@@ -48,12 +47,12 @@ public class TextModel : ProfessionalReferralSessionModel, ISingleTelephoneTextb
 
         model.TextphoneNumber = TextBoxValue;
 
-        return NextPage(ConnectJourneyPage.Textphone, model.ContactMethodsSelected);
+        return NextPage(ConnectContactDetailsJourneyPage.Textphone, model.ContactMethodsSelected);
     }
 
     private void SetPageProperties(ConnectionRequestModel model)
     {
         HeadingText = $"What telephone number should the service use to text {model.FamilyContactFullName}?";
-        BackUrl = PreviousPage(ConnectJourneyPage.Textphone, model.ContactMethodsSelected);
+        BackUrl = GenerateBackUrl(ConnectContactDetailsJourneyPage.Textphone, model.ContactMethodsSelected);
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Text.cshtml.cs
@@ -6,7 +6,9 @@ using FamilyHubs.Referral.Core.DistributedCache;
 using FamilyHubs.Referral.Web.Models;
 
 namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral;
-
+//todo: fix check details -> change contact methods change selection e.g. from text to phone, continue, then back and back again to check details & previous captured text has now been deleted
+// need to clear not selected, either on post of last contact details page, or on get of check details page
+// will mean if you eg. select phone, enter phone, go back, select text, enter text, got back, select phone again and it will have remembered the original phone, but think that's ok
 public class TextModel : ProfessionalReferralSessionModel, ISingleTelephoneTextboxPageModel
 {
     public string HeadingText { get; set; } = "";

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/WhySupport.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/WhySupport.cshtml
@@ -6,7 +6,7 @@
 }
 
 @section Back {
-    <a asp-page="/ProfessionalReferral/SupportDetails" asp-route-serviceId="@Model.ServiceId" class="govuk-back-link">Back</a>
+    <a href="@Model.BackUrl" class="govuk-back-link">Back</a>
 }
 
 <partial name="/Pages/Shared/_TellTheServicePage.cshtml" model="Model"/>

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/WhySupport.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/WhySupport.cshtml.cs
@@ -15,7 +15,7 @@ public class WhySupportModel : ProfessionalReferralSessionModel, ITellTheService
     public string? TextAreaValue { get; set; }
 
     public WhySupportModel(IConnectionRequestDistributedCache connectionRequestCache)
-        : base(connectionRequestCache)
+        : base(ConnectJourneyPage.WhySupport, connectionRequestCache)
     {
     }
 

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/WhySupport.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/WhySupport.cshtml.cs
@@ -29,7 +29,7 @@ public class WhySupportModel : ProfessionalReferralSessionModel, ITellTheService
     {
         if (string.IsNullOrEmpty(TextAreaValue))
         {
-            TextAreaValidationErrorMessage = "Enter reason for the connection request";
+            TextAreaValidationErrorMessage = "Enter details about the family";
             return null;
         }
 

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
@@ -52,7 +52,7 @@ public class ProfessionalReferralModel : PageModel
         return Task.FromResult((IActionResult)Page());
     }
 
-    public async Task<IActionResult> OnGetAsync(string serviceId)
+    public async Task<IActionResult> OnGetAsync(string serviceId, string? changing = null)
     {
         if (serviceId == null)
         {
@@ -64,25 +64,32 @@ public class ProfessionalReferralModel : PageModel
 
         ServiceId = serviceId;
 
+        Flow = GetFlow(changing);
+
         // default, but can be overridden
         BackUrl = GenerateBackUrl((_page-1).ToString());
 
         return await OnSafeGetAsync();
     }
 
-    public async Task<IActionResult> OnPostAsync(string serviceId, string? changing = null)
+    private JourneyFlow GetFlow(string? changing)
     {
-        ServiceId = serviceId;
-
-        // default, but can be overridden
-        BackUrl = GenerateBackUrl((_page-1).ToString());
-
-        Flow = changing switch
+        return changing switch
         {
             "page" => JourneyFlow.ChangingPage,
             "contact-methods" => JourneyFlow.ChangingContactMethods,
             _ => JourneyFlow.Normal
         };
+    }
+
+    public async Task<IActionResult> OnPostAsync(string serviceId, string? changing = null)
+    {
+        ServiceId = serviceId;
+
+        Flow = GetFlow(changing);
+
+        // default, but can be overridden
+        BackUrl = GenerateBackUrl((_page-1).ToString());
 
         return await OnSafePostAsync();
     }

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
@@ -118,11 +118,6 @@ public class ProfessionalReferralModel : PageModel
             Flow == JourneyFlow.ChangingPage ? "CheckDetails" : page);
     }
 
-    //protected string PreviousPage(string page)
-    //{
-    //    return Flow == JourneyFlow.ChangingPage ? "CheckDetails" : page;
-    //}
-
     //todo: work with enums until the last possible moment
     //todo: better split between this and session model
     protected string GenerateBackUrl(string page)

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
@@ -123,16 +123,29 @@ public class ProfessionalReferralModel : PageModel
     //    return Flow == JourneyFlow.ChangingPage ? "CheckDetails" : page;
     //}
 
+    //todo: work with enums until the last possible moment
     //todo: better split between this and session model
     protected string GenerateBackUrl(string page)
     {
-        string backUrlPage = Flow == JourneyFlow.ChangingPage ? "CheckDetails" : page;
+        string? backUrlPage;
+            
+        if (Flow == JourneyFlow.ChangingContactMethods
+            && page == ConnectJourneyPage.WhySupport.ToString()) // ContactMethods-1
+        {
+            backUrlPage = "CheckDetails";
+        }
+        else
+        {
+            backUrlPage = Flow == JourneyFlow.ChangingPage ? "CheckDetails" : page;
+        }
+
 
         dynamic dynamicObject = new System.Dynamic.ExpandoObject();
         //todo: check for null
         dynamicObject.ServiceId = ServiceId;
 
-        if (Flow == JourneyFlow.ChangingContactMethods)
+        if (Flow == JourneyFlow.ChangingContactMethods
+            && backUrlPage != "CheckDetails" && backUrlPage != "WhySupport")
         {
             dynamicObject.changing = "contact-methods";
         }

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
@@ -25,7 +25,7 @@ public class ProfessionalReferralModel : PageModel
         return Task.FromResult((IActionResult)Page());
     }
 
-    public async Task<IActionResult> OnGetAsync(string serviceId, string? changing = null)
+    public async Task<IActionResult> OnGetAsync(string serviceId)
     {
         if (serviceId == null)
         {
@@ -37,20 +37,19 @@ public class ProfessionalReferralModel : PageModel
 
         ServiceId = serviceId;
 
-        //todo: move page next/previous into here and handle all journey pages here, or here and derived
+        return await OnSafeGetAsync();
+    }
+
+    public async Task<IActionResult> OnPostAsync(string serviceId, string? changing = null)
+    {
+        ServiceId = serviceId;
+
         Flow = changing switch
         {
             "page" => JourneyFlow.ChangingPage,
             "contact-methods" => JourneyFlow.ChangingContactMethods,
             _ => JourneyFlow.Normal
         };
-
-        return await OnSafeGetAsync();
-    }
-
-    public async Task<IActionResult> OnPostAsync(string serviceId)
-    {
-        ServiceId = serviceId;
 
         return await OnSafePostAsync();
     }
@@ -61,5 +60,12 @@ public class ProfessionalReferralModel : PageModel
         {
             ServiceId
         });
+    }
+
+    //todo: consts, if not an enum
+    protected IActionResult NextPage(string page)
+    {
+        return RedirectToProfessionalReferralPage(
+            Flow == JourneyFlow.ChangingPage ? "CheckDetails" : page);
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
@@ -65,6 +65,15 @@ public class ProfessionalReferralModel : PageModel
     //todo: consts, if not an enum
     protected IActionResult NextPage(string page)
     {
+        if (Flow == JourneyFlow.ChangingContactMethods)
+        {
+            return RedirectToPage($"/ProfessionalReferral/{page}", new
+            {
+                ServiceId,
+                changing = "contact-methods"
+            });
+        }
+
         return RedirectToProfessionalReferralPage(
             Flow == JourneyFlow.ChangingPage ? "CheckDetails" : page);
     }

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
@@ -3,9 +3,17 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FamilyHubs.Referral.Web.Pages.Shared;
 
+public enum JourneyFlow
+{
+    Normal,
+    ChangingPage,
+    ChangingContactMethods
+}
+
 public class ProfessionalReferralModel : PageModel
 {
     public string? ServiceId { get; set; }
+    public JourneyFlow Flow { get; set; }
 
     protected virtual Task<IActionResult> OnSafeGetAsync()
     {
@@ -17,7 +25,7 @@ public class ProfessionalReferralModel : PageModel
         return Task.FromResult((IActionResult)Page());
     }
 
-    public async Task<IActionResult> OnGetAsync(string serviceId)
+    public async Task<IActionResult> OnGetAsync(string serviceId, string? changing = null)
     {
         if (serviceId == null)
         {
@@ -28,6 +36,14 @@ public class ProfessionalReferralModel : PageModel
         }
 
         ServiceId = serviceId;
+
+        //todo: move page next/previous into here and handle all journey pages here, or here and derived
+        Flow = changing switch
+        {
+            "page" => JourneyFlow.ChangingPage,
+            "contact-methods" => JourneyFlow.ChangingContactMethods,
+            _ => JourneyFlow.Normal
+        };
 
         return await OnSafeGetAsync();
     }

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralModel.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FamilyHubs.Referral.Web.Pages.Shared;
 
-//todo: back to errored page asked to resubmit form??
+//todo: use post redirect get pattern so that errored pages don't ask for a reload (especially when using back)
 
 public enum JourneyFlow
 {
@@ -140,17 +140,15 @@ public class ProfessionalReferralModel : PageModel
         }
 
 
-        dynamic dynamicObject = new System.Dynamic.ExpandoObject();
-        //todo: check for null
-        dynamicObject.ServiceId = ServiceId;
+        //todo: check ServiceId for null
+        string url = $"/ProfessionalReferral/{backUrlPage}?ServiceId={ServiceId}";
 
         if (Flow == JourneyFlow.ChangingContactMethods
             && backUrlPage != "CheckDetails" && backUrlPage != "WhySupport")
         {
-            dynamicObject.changing = "contact-methods";
+            url = $"{url}&changing=contact-methods";
         }
 
-        //todo: unit testing BackUrl when it uses this is going to be a pain. just do it manually instead?
-        return UrlHelperExtensions.Page(Url, $"/ProfessionalReferral/{backUrlPage}", dynamicObject);
+        return url;
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace FamilyHubs.Referral.Web.Pages.Shared;
 
-//todo: once we start storing the model in the session, switch to storing the service id and name in the session, rather than the url?
 public abstract class ProfessionalReferralSessionModel : ProfessionalReferralModel
 {
     public bool ValidationValid { get; set; } = true;

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
@@ -75,12 +75,23 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
 
     protected string NextPage(ConnectJourneyPage currentPage, bool[] contactMethodsSelected)
     {
+        // we could do this, but should be handled later anyway
+        //if (Flow == JourneyFlow.ChangingPage)
+        //{
+        //    return "CheckDetails";
+        //}
+
         while (++currentPage <= ConnectJourneyPage.LastContactMethod)
         {
             if (contactMethodsSelected[(int) currentPage])
             {
                 break;
             }
+        }
+
+        if (Flow == JourneyFlow.ChangingContactMethods && (int)currentPage == _connectJourneyPages.Length)
+        {
+            return "CheckDetails";
         }
 
         return _connectJourneyPages[(int)currentPage+1];

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
@@ -89,7 +89,8 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
             }
         }
 
-        if (Flow == JourneyFlow.ChangingContactMethods && (int)currentPage == _connectJourneyPages.Length)
+        if (Flow == JourneyFlow.ChangingContactMethods
+            && currentPage == ConnectJourneyPage.ContactMethods)
         {
             return "CheckDetails";
         }

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
@@ -54,7 +54,7 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
 
         await ConnectionRequestCache.SetAsync(model);
 
-        return RedirectToProfessionalReferralPage(nextPage);
+        return NextPage(nextPage);
     }
 
     //todo: probably want to move these into the base?

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
@@ -117,11 +117,11 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
             }
         }
 
-        if (Flow == JourneyFlow.ChangingContactMethods
-            && currentPage == ConnectContactDetailsJourneyPage.ContactMethods)
-        {
-            return "CheckDetails";
-        }
+        //if (Flow == JourneyFlow.ChangingContactMethods
+        //    && currentPage == ConnectContactDetailsJourneyPage.ContactMethods)
+        //{
+        //    return "CheckDetails";
+        //}
 
         return _connectJourneyPages[(int)currentPage + 1];
     }

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/ProfessionalReferralSessionModel.cs
@@ -10,7 +10,10 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
 
     protected readonly IConnectionRequestDistributedCache ConnectionRequestCache;
 
-    protected ProfessionalReferralSessionModel(IConnectionRequestDistributedCache connectionRequestCache)
+    protected ProfessionalReferralSessionModel(
+        ConnectJourneyPage page,
+        IConnectionRequestDistributedCache connectionRequestCache)
+        : base(page)
     {
         ConnectionRequestCache = connectionRequestCache;
     }
@@ -58,6 +61,7 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
     }
 
     //todo: probably want to move these into the base?
+    //todo: once enums merged, just use tostring instead
     private static string[] _connectJourneyPages =
     {
         "ContactDetails",
@@ -70,10 +74,10 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
 
     protected string FirstContactMethodPage(bool[] contactMethodsSelected)
     {
-        return NextPage((ConnectJourneyPage)(-1), contactMethodsSelected);
+        return NextPage((ConnectContactDetailsJourneyPage)(-1), contactMethodsSelected);
     }
 
-    protected string NextPage(ConnectJourneyPage currentPage, bool[] contactMethodsSelected)
+    protected string NextPage(ConnectContactDetailsJourneyPage currentPage, bool[] contactMethodsSelected)
     {
         // we could do this, but should be handled later anyway
         //if (Flow == JourneyFlow.ChangingPage)
@@ -81,7 +85,7 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
         //    return "CheckDetails";
         //}
 
-        while (++currentPage <= ConnectJourneyPage.LastContactMethod)
+        while (++currentPage <= ConnectContactDetailsJourneyPage.LastContactMethod)
         {
             if (contactMethodsSelected[(int) currentPage])
             {
@@ -90,7 +94,7 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
         }
 
         if (Flow == JourneyFlow.ChangingContactMethods
-            && currentPage == ConnectJourneyPage.ContactMethods)
+            && currentPage == ConnectContactDetailsJourneyPage.ContactMethods)
         {
             return "CheckDetails";
         }
@@ -98,7 +102,12 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
         return _connectJourneyPages[(int)currentPage+1];
     }
 
-    protected string PreviousPage(ConnectJourneyPage currentPage, bool[] contactMethodsSelected)
+    protected string GenerateBackUrl(ConnectContactDetailsJourneyPage currentPage, bool[] contactMethodsSelected)
+    {
+        return GenerateBackUrl(PreviousPage(currentPage, contactMethodsSelected));
+    }
+
+    private string PreviousPage(ConnectContactDetailsJourneyPage currentPage, bool[] contactMethodsSelected)
     {
         while (--currentPage >= 0)
         {
@@ -106,6 +115,12 @@ public abstract class ProfessionalReferralSessionModel : ProfessionalReferralMod
             {
                 break;
             }
+        }
+
+        if (Flow == JourneyFlow.ChangingContactMethods
+            && currentPage == ConnectContactDetailsJourneyPage.ContactMethods)
+        {
+            return "CheckDetails";
         }
 
         return _connectJourneyPages[(int)currentPage + 1];

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/_SingleTextboxPage.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/_SingleTextboxPage.cshtml
@@ -64,7 +64,7 @@
 
                 <input class="govuk-input @(Model.ValidationValid ? "" : "govuk-input--error")"
                        name="TextBoxValue" type="@type" value="@Model.TextBoxValue" inputmode="@type"
-                       spellcheck="false" autocomplete="off" id="textbox" aria-describedby="hint error">
+                       spellcheck="false" autocomplete="off" id="textbox" aria-describedby="hint @(Model.ValidationValid ? "" : "error")">
             </div>
             <button type="submit" class="govuk-button" data-module="govuk-button">
                 Continue

--- a/src/FamilyHubs.Referral.Web/Pages/Shared/_TellTheServicePage.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/Shared/_TellTheServicePage.cshtml
@@ -49,11 +49,11 @@
                 <div id="reason-info" class="govuk-hint govuk-character-count__message">
                     You can enter up to 500 characters
                 </div>
-
-                <button type="submit" class="govuk-button" data-module="govuk-button">
-                    Continue
-                </button>
             </div>
+
+            <button type="submit" class="govuk-button" data-module="govuk-button">
+                Continue
+            </button>
         </form>
     </div>
 </div>

--- a/src/FamilyHubs.Referral.Web/StartupExtensions.cs
+++ b/src/FamilyHubs.Referral.Web/StartupExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using FamilyHubs.Referral.Core.ApiClients;
+using FamilyHubs.Referral.Core.DistributedCache;
+using FamilyHubs.Referral.Web.DistributedCache;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
@@ -65,6 +67,7 @@ public static class StartupExtensions
         services.AddReferralDistributedCache(
             configuration["RedisCache:Connection"],
             int.Parse(configuration["RedisCache:SlidingExpirationInMinutes"] ?? "240"));
+        services.AddTransient<ICacheKeys, CacheKeys>();
     }
 
     public static void AddHttpClients(this IServiceCollection services, IConfiguration configuration)

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Core/ValidationAttributes/UKGdsPostcodeAttributeTests.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Core/ValidationAttributes/UKGdsPostcodeAttributeTests.cs
@@ -4,11 +4,11 @@ namespace FamilyHubs.ReferralUi.UnitTests.Core.ValidationAttributes;
 
 public class UKGdsPostcodeAttributeTests
 {
-    public UKGdsPostcodeAttribute UKGdsPostcodeAttribute { get; set; }
+    public UkGdsPostcodeAttribute UKGdsPostcodeAttribute { get; set; }
 
     public UKGdsPostcodeAttributeTests()
     {
-        UKGdsPostcodeAttribute = new UKGdsPostcodeAttribute();
+        UKGdsPostcodeAttribute = new UkGdsPostcodeAttribute();
     }
 
     [Theory]
@@ -74,7 +74,7 @@ public class UKGdsPostcodeAttributeTests
     public void SanitisePostcode_WhenPostcodeIsSupplied_ReturnsSanitisedPostcode(string expectedPostcode, string postcode)
     {
         // Act
-        string result = UKGdsPostcodeAttribute.SanitisePostcode(postcode);
+        string result = UkGdsPostcodeAttribute.SanitisePostcode(postcode);
 
         Assert.Equal(expectedPostcode, result);
     }

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Core/ValidationAttributes/UKGdsTelephoneNumberAttributeTests.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Core/ValidationAttributes/UKGdsTelephoneNumberAttributeTests.cs
@@ -13,15 +13,95 @@ public class UKGdsTelephoneNumberAttributeTests
     }
 
     [Theory]
-    [InlineData(true, "(01788) 861 384")]
+    // GDS says allow country code
     [InlineData(true, "+44 808 157 0192")]
+
+    // GDS says allow country code, but we're only allowing UK numbers
+    [InlineData(false, "+1 212-555-1234")]
+    [InlineData(false, "+61 2 5555 1234")]
+    [InlineData(false, "+86 10 5555 1234")]
+
+    // no spaces
     [InlineData(true, "01656861385")]
+    [InlineData(true, "07462602236")]
+
+    // example vanity numbers (not really a thing in the UK), but libphonenumber allows it
+    [InlineData(true, "0746260abcd")]
+
+    // if someone mistypes and replaces a number with a letter, it's taken as invalid
+    [InlineData(false, "0746260a123")]
+
+    // an extra alpha or two in the middle of a valid number are ignored
+    [InlineData(true, "0746260a1234")]
+    [InlineData(true, "0746260A1234")]
+    [InlineData(true, "0746260i1234")]
+    [InlineData(true, "0746260ig1234")]
+
+    // any more than two are classed as invalid
+    [InlineData(false, "0746260ign1234")]
+    [InlineData(false, "0746260igno1234")]
+    [InlineData(false, "0746260ignor1234")]
+    [InlineData(false, "0746260ignore1234")]
+    [InlineData(false, "0746260ignored1234")]
+
+    // some alphas can't be part of vanity numbers
+    [InlineData(false, "0746260q234")]
+    [InlineData(false, "0746260Q234")]
+    [InlineData(false, "0746260z234")]
+    [InlineData(false, "0746260Z234")]
+
+    // GDS says allow additional spaces, hyphens, dashes and brackets
+
+    // spaces
+    [InlineData(true, "01656 861 384")]
+    [InlineData(true, "07462 602236")]
+    [InlineData(true, " 0 7 4 6 2 6 0 2 2 3 6 ")]
+
+    // hyphen
     [InlineData(true, "+44-808-157-0192")]
+    [InlineData(true, "-+44-808-157-0192-")]
+    // em dash
+    [InlineData(true, "+44—808—157—0193")]
+    // en dash
+    [InlineData(true, "+44–808–157–0194")]
+
+    // brackets
+    [InlineData(true, "(01788)861384")]
+    [InlineData(true, "01788(861)384")]
+    [InlineData(true, "[01788]861384")]
+
+    // mix
+    [InlineData(true, "(01788) 861 384")]
+    [InlineData(true, "01788 (861) 384")]
+    [InlineData(true, "01788 861 (384)")]
+    [InlineData(true, "(01788) (861) (384)")]
+    [InlineData(true, "+44-[808]-157-0192")]
     [InlineData(true, "+44-(808)-157-0192")]
     [InlineData(true, "+44-808-(157)-0192")]
     [InlineData(true, "+44-808-157-(0192)")]
-    [InlineData(true, "01656 861 384")]
-    [InlineData(true, "07462 602236")]
+    [InlineData(true, "+]4((4)]-808-157-(0192)")]
+
+    // non-numbers
+    [InlineData(false, "my number")]
+    [InlineData(false, "MYNUMBER")]
+    [InlineData(false, "x")]
+    [InlineData(false, "X")]
+
+    // invalid punctuation
+    [InlineData(false, "+<44-808-157-0192>")]
+    [InlineData(false, "+44!808!157!0192>")]
+    // libphonenumber for some reason allows this. has it got a borked regex?
+    [InlineData(false, "+448081570192$")]
+    [InlineData(false, "+44808157019$2")]
+    [InlineData(false, "^+448081570192")]
+    [InlineData(false, "*+448081570192")]
+    [InlineData(false, "£+448081570192")]
+
+    // some examples we may see (these sort of things can be entered into the 'how to engage with the family' field) later on)
+    [InlineData(false, "01656861389 before the 12th May, 01722474474 after")]
+    [InlineData(false, "On weekdays 01656861389 and on the weekend try 01722474474 or 0797627272")]
+    [InlineData(false, "Either 01656861389 or 01656861389")]
+    [InlineData(false, "try hostel:01656861389, Friends house:01656861389")]
 
     // UK-wide : OK, contact might be giving a work number (probably with an extension)
     [InlineData(true, "03069 990000")]

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Core/ValidationAttributes/UKGdsTelephoneNumberAttributeTests.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Core/ValidationAttributes/UKGdsTelephoneNumberAttributeTests.cs
@@ -5,11 +5,11 @@ namespace FamilyHubs.ReferralUi.UnitTests.Core.ValidationAttributes;
 
 public class UKGdsTelephoneNumberAttributeTests
 {
-    public UKGdsTelephoneNumberAttribute UKGdsTelephoneNumberAttribute { get; set; }
+    public UkGdsTelephoneNumberAttribute UKGdsTelephoneNumberAttribute { get; set; }
 
     public UKGdsTelephoneNumberAttributeTests()
     {
-        UKGdsTelephoneNumberAttribute = new UKGdsTelephoneNumberAttribute();
+        UKGdsTelephoneNumberAttribute = new UkGdsTelephoneNumberAttribute();
     }
 
     [Theory]

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Core/ValidationAttributes/UKGdsTelephoneNumberAttributeTests.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Core/ValidationAttributes/UKGdsTelephoneNumberAttributeTests.cs
@@ -1,0 +1,65 @@
+﻿using FamilyHubs.Referral.Core.ValidationAttributes;
+using FluentAssertions;
+
+namespace FamilyHubs.ReferralUi.UnitTests.Core.ValidationAttributes;
+
+public class UKGdsTelephoneNumberAttributeTests
+{
+    public UKGdsTelephoneNumberAttribute UKGdsTelephoneNumberAttribute { get; set; }
+
+    public UKGdsTelephoneNumberAttributeTests()
+    {
+        UKGdsTelephoneNumberAttribute = new UKGdsTelephoneNumberAttribute();
+    }
+
+    [Theory]
+    [InlineData(true, "(01788) 861 384")]
+    [InlineData(true, "+44 808 157 0192")]
+    [InlineData(true, "01656861385")]
+    [InlineData(true, "+44-808-157-0192")]
+    [InlineData(true, "+44-(808)-157-0192")]
+    [InlineData(true, "+44-808-(157)-0192")]
+    [InlineData(true, "+44-808-157-(0192)")]
+    [InlineData(true, "01656 861 384")]
+    [InlineData(true, "07462 602236")]
+
+    // UK-wide : OK, contact might be giving a work number (probably with an extension)
+    [InlineData(true, "03069 990000")]
+    // Premium rate : we probably don't want to allow these, or at least warn the user
+    [InlineData(true, "0909 8790000")]
+    // Freephone
+    [InlineData(true, "08081 570000")]
+
+    // valid extension formats
+    [InlineData(true, "01656 861 384 ext. 12345")]
+    [InlineData(true, "01656 861 384#1")]
+    [InlineData(true, "01656 861 384 x 123")]
+    [InlineData(true, "01656 861 384 extension 12345678")]
+
+    // invalid extension formats
+    [InlineData(false, "01656 861 384 e 12345678")]
+    [InlineData(false, "01656 861 384 bob 12345678")]
+
+    // incorrect number of digits
+    [InlineData(false, "0")]
+    [InlineData(false, "01")]
+    [InlineData(false, "016")]
+    [InlineData(false, "0165")]
+    [InlineData(false, "01656")]
+    [InlineData(false, "01656 8")]
+    [InlineData(false, "01656 86")]
+    [InlineData(false, "01656 861")]
+    [InlineData(false, "01656 861 3")]
+    [InlineData(false, "01656 861 38")]
+    [InlineData(false, "01656 861 3845")]
+    [InlineData(false, "01656 861 38456")]
+
+    // this is a designated example number, and is in a valid format, but it's not a real geographic area code
+    [InlineData(false, "01632 960 001")]
+    // this is a designated example mobile number, and is in  a valid format, but it's not a real mobile area code
+    [InlineData(false, "07700 900 982")]
+    public void IsValid_ShouldReturnIfNumberIsValid(bool expected, string number)
+    {
+        UKGdsTelephoneNumberAttribute.IsValid(number).Should().Be(expected);
+    }
+}

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Infrastructure/DistributedCache/ReferralCacheKeysTests.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Infrastructure/DistributedCache/ReferralCacheKeysTests.cs
@@ -1,4 +1,5 @@
 ﻿using FamilyHubs.Referral.Infrastructure.DistributedCache;
+using FamilyHubs.Referral.Web.DistributedCache;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Moq;

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingConsent.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingConsent.cs
@@ -1,6 +1,8 @@
 ﻿using FamilyHubs.Referral.Web.Pages.ProfessionalReferral;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Moq;
 
 namespace FamilyHubs.ReferralUi.UnitTests.Web.Pages.ProfessionalReferral;
 
@@ -8,9 +10,48 @@ public class WhenUsingConsent
 {
     private readonly ConsentModel _consentModel;
 
+    //todo: either move this down into a base or change the cut not to use the UrlHelper?
+    private Mock<IUrlHelper> CreateMockUrlHelper(ActionContext? context = null)
+    {
+        context ??= GetActionContextForPage("/Page");
+
+        var urlHelper = new Mock<IUrlHelper>();
+        urlHelper.SetupGet(h => h.ActionContext)
+            .Returns(context);
+        return urlHelper;
+    }
+
+    private static ActionContext GetActionContextForPage(string page)
+    {
+        return new()
+        {
+            ActionDescriptor = new()
+            {
+                RouteValues = new Dictionary<string, string?>
+                {
+                    { "page", page }
+                }
+            },
+            RouteData = new()
+            {
+                Values =
+                {
+                    [ "page" ] = page
+                }
+            }
+        };
+    }
+
     public WhenUsingConsent()
     {
-        _consentModel = new ConsentModel();
+        var mockUrlHelper = CreateMockUrlHelper();
+        mockUrlHelper.Setup(h => h.RouteUrl(It.IsAny<UrlRouteContext>()))
+            .Returns("callbackUrl");
+
+        _consentModel = new ConsentModel
+        {
+            Url = mockUrlHelper.Object
+        };
     }
 
     [Fact]

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingConsent.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingConsent.cs
@@ -10,48 +10,9 @@ public class WhenUsingConsent
 {
     private readonly ConsentModel _consentModel;
 
-    //todo: either move this down into a base or change the cut not to use the UrlHelper?
-    private Mock<IUrlHelper> CreateMockUrlHelper(ActionContext? context = null)
-    {
-        context ??= GetActionContextForPage("/Page");
-
-        var urlHelper = new Mock<IUrlHelper>();
-        urlHelper.SetupGet(h => h.ActionContext)
-            .Returns(context);
-        return urlHelper;
-    }
-
-    private static ActionContext GetActionContextForPage(string page)
-    {
-        return new()
-        {
-            ActionDescriptor = new()
-            {
-                RouteValues = new Dictionary<string, string?>
-                {
-                    { "page", page }
-                }
-            },
-            RouteData = new()
-            {
-                Values =
-                {
-                    [ "page" ] = page
-                }
-            }
-        };
-    }
-
     public WhenUsingConsent()
     {
-        var mockUrlHelper = CreateMockUrlHelper();
-        mockUrlHelper.Setup(h => h.RouteUrl(It.IsAny<UrlRouteContext>()))
-            .Returns("callbackUrl");
-
-        _consentModel = new ConsentModel
-        {
-            Url = mockUrlHelper.Object
-        };
+        _consentModel = new ConsentModel();
     }
 
     [Fact]

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingContactDetails.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingContactDetails.cs
@@ -23,18 +23,18 @@ public class WhenUsingContactDetails : BaseProfessionalReferralPage
     [InlineData(true, true, true, true)]
     public async Task ThenCheckboxesShouldMatchRetrievedModel(bool email, bool telephone, bool textphone, bool letter)
     {
-        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectJourneyPage.Email] = email;
-        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectJourneyPage.Telephone] = telephone;
-        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectJourneyPage.Textphone] = textphone;
-        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectJourneyPage.Letter] = letter;
+        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectContactDetailsJourneyPage.Email] = email;
+        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectContactDetailsJourneyPage.Telephone] = telephone;
+        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectContactDetailsJourneyPage.Textphone] = textphone;
+        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectContactDetailsJourneyPage.Letter] = letter;
 
         //Act
         await _contactDetailsModel.OnGetAsync("1");
 
-        _contactDetailsModel.ContactMethods[(int)ConnectJourneyPage.Email].Should().Be(email);
-        _contactDetailsModel.ContactMethods[(int)ConnectJourneyPage.Telephone].Should().Be(telephone);
-        _contactDetailsModel.ContactMethods[(int)ConnectJourneyPage.Textphone].Should().Be(textphone);
-        _contactDetailsModel.ContactMethods[(int)ConnectJourneyPage.Letter].Should().Be(letter);
+        _contactDetailsModel.ContactMethods[(int)ConnectContactDetailsJourneyPage.Email].Should().Be(email);
+        _contactDetailsModel.ContactMethods[(int)ConnectContactDetailsJourneyPage.Telephone].Should().Be(telephone);
+        _contactDetailsModel.ContactMethods[(int)ConnectContactDetailsJourneyPage.Textphone].Should().Be(textphone);
+        _contactDetailsModel.ContactMethods[(int)ConnectContactDetailsJourneyPage.Letter].Should().Be(letter);
     }
 
     [Theory]
@@ -47,10 +47,10 @@ public class WhenUsingContactDetails : BaseProfessionalReferralPage
     [InlineData("/ProfessionalReferral/Text", false, false, true, true)]
     public async Task ThenOnPostSupportDetails(string expectedNextPage, bool email, bool telephone, bool textphone, bool letter)
     {
-        _contactDetailsModel.ContactMethods[(int)ConnectJourneyPage.Email] = email;
-        _contactDetailsModel.ContactMethods[(int)ConnectJourneyPage.Telephone] = telephone;
-        _contactDetailsModel.ContactMethods[(int)ConnectJourneyPage.Textphone] = textphone;
-        _contactDetailsModel.ContactMethods[(int)ConnectJourneyPage.Letter] = letter;
+        _contactDetailsModel.ContactMethods[(int)ConnectContactDetailsJourneyPage.Email] = email;
+        _contactDetailsModel.ContactMethods[(int)ConnectContactDetailsJourneyPage.Telephone] = telephone;
+        _contactDetailsModel.ContactMethods[(int)ConnectContactDetailsJourneyPage.Textphone] = textphone;
+        _contactDetailsModel.ContactMethods[(int)ConnectContactDetailsJourneyPage.Letter] = letter;
 
         //Act
         var result = await _contactDetailsModel.OnPostAsync("1") as RedirectToPageResult;

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingContactMethods.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingContactMethods.cs
@@ -60,7 +60,7 @@ public class WhenUsingContactMethods : BaseProfessionalReferralPage
         result.PageName.Should().Be("/ProfessionalReferral/CheckDetails");
     }
 
-    private const string EmptyErrorMessage = "Enter details about the family";
+    private const string EmptyErrorMessage = "Enter how best to engage with this family";
     private const string TooLongErrorMessage = "How the service can engage with the family must be 500 characters or less";
 
     [Theory]

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingEmail.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingEmail.cs
@@ -32,9 +32,9 @@ public class WhenUsingEmail : BaseProfessionalReferralPage
     [InlineData("/ProfessionalReferral/ContactMethods", false, false, false)]
     public async Task ThenOnPostEmail(string expectedNextPage, bool telephone, bool textphone, bool letter)
     {
-        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectJourneyPage.Telephone] = telephone;
-        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectJourneyPage.Textphone] = textphone;
-        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectJourneyPage.Letter] = letter;
+        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectContactDetailsJourneyPage.Telephone] = telephone;
+        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectContactDetailsJourneyPage.Textphone] = textphone;
+        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectContactDetailsJourneyPage.Letter] = letter;
 
         _emailModel.TextBoxValue = "someone@email.com";
 

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingTelephone.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingTelephone.cs
@@ -31,8 +31,8 @@ public class WhenUsingTelephone : BaseProfessionalReferralPage
     [InlineData("/ProfessionalReferral/ContactMethods", false, false)]
     public async Task ThenOnPostEmail(string expectedNextPage, bool textphone, bool letter)
     {
-        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectJourneyPage.Textphone] = textphone;
-        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectJourneyPage.Letter] = letter;
+        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectContactDetailsJourneyPage.Textphone] = textphone;
+        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectContactDetailsJourneyPage.Letter] = letter;
 
         _telephoneModel.TextBoxValue = Telephone;
 

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingText.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingText.cs
@@ -29,7 +29,7 @@ public class WhenUsingText : BaseProfessionalReferralPage
     [InlineData("/ProfessionalReferral/ContactMethods", false)]
     public async Task ThenOnPostEmail(string expectedNextPage, bool letter)
     {
-        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectJourneyPage.Letter] = letter;
+        ConnectionRequestModel.ContactMethodsSelected[(int)ConnectContactDetailsJourneyPage.Letter] = letter;
 
         _textModel.TextBoxValue = Telephone;
 

--- a/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingWhySupport.cs
+++ b/tests/FamilyHubs.ReferralUi.UnitTests/Web/Pages/ProfessionalReferral/WhenUsingWhySupport.cs
@@ -41,7 +41,7 @@ public class WhenUsingWhySupport : BaseProfessionalReferralPage
         result.PageName.Should().Be("/ProfessionalReferral/ContactDetails");
     }
 
-    private const string EmptyErrorMessage = "Enter reason for the connection request";
+    private const string EmptyErrorMessage = "Enter details about the family";
     private const string TooLongErrorMessage = "Reason for the connection request must be 500 characters or less";
 
     [Theory]


### PR DESCRIPTION
Includes the 'Get' for the check details page, including the change details journey navigation.

Also includes:
* update error messages when user doesn't enter anything for 'details about the family' and 'how to engage with the family'
* fixes an accessibility issue on pages with a single text box (e.g. 'enter telephone number'). The aria-desribedby referenced a non-existent element when there was no error message
* fix spacing between textarea and continue button (on reason and engage pages)
* remove trailing full-stops on error messages on letter page