### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,10 @@ To debug the JavaScript in Visual Studio, set breakpoints in the JavaScript file
 
 * open / close filter button doesn't work - create a component from the find site.
 
+* journey edge case
+
+* tell the service pages count mismatch wrt cr/lf
+
+* sign-in expiry (cookie expires with session, but no session)
+
 * add prg to telephone, text & letter

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ To debug the JavaScript in Visual Studio, set breakpoints in the JavaScript file
 
 * journey edge case
 
-* tell the service pages count mismatch wrt cr/lf
-
 * sign-in expiry (cookie expires with session, but no session)
 
 * add prg to telephone, text & letter

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Confirmation.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/Confirmation.cshtml.cs
@@ -1,13 +1,21 @@
+using FamilyHubs.SharedKernel.Razor.FamilyHubsUi.Delegators;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FamilyHubs.Referral.Web.Pages.ProfessionalReferral;
 
-public class ConfirmationModel : PageModel
+[Authorize]
+public class ConfirmationModel : PageModel, IFamilyHubsHeader
 {
     public int RequestNumber { get; set; }
 
     public void OnGet(int requestNumber)
     {
         RequestNumber = requestNumber;
+    }
+
+    LinkStatus IFamilyHubsHeader.GetStatus(SharedKernel.Razor.FamilyHubsUi.Options.LinkOptions link)
+    {
+        return link.Text == "Search for service" ? LinkStatus.Active : LinkStatus.Visible;
     }
 }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactMethods.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/ContactMethods.cshtml.cs
@@ -48,7 +48,9 @@ public class ContactMethodsModel : ProfessionalReferralCacheModel, ITellTheServi
             return RedirectToSelf(null,ProfessionalReferralError.ContactMethods_NothingEntered);
         }
 
-        if (TextAreaValue.Length > 500)
+        // workaround the front end counting line endings as 1 chars (\n) as per HTML spec,
+        // and the http transport/.net/windows using 2 chars for line ends (\r\n)
+        if (TextAreaValue.Replace("\r", "").Length > 500)
         {
             return RedirectToSelf(TextAreaValue, ProfessionalReferralError.ContactMethods_TooLong);
         }

--- a/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/WhySupport.cshtml.cs
+++ b/src/FamilyHubs.Referral.Web/Pages/ProfessionalReferral/WhySupport.cshtml.cs
@@ -48,7 +48,9 @@ public class WhySupportModel : ProfessionalReferralCacheModel, ITellTheServicePa
             return RedirectToSelf(null, ProfessionalReferralError.WhySupport_NothingEntered);
         }
 
-        if (TextAreaValue.Length > 500)
+        // workaround the front end counting line endings as 1 chars (\n) as per HTML spec,
+        // and the http transport/.net/windows using 2 chars for line ends (\r\n)
+        if (TextAreaValue.Replace("\r", "").Length > 500)
         {
             return RedirectToSelf(TextAreaValue, ProfessionalReferralError.WhySupport_TooLong);
         }


### PR DESCRIPTION
Includes:
* confirmation page wasn't authorisation protected and was missing the links in the header
* fix 'too long' validation on 'tell the service' pages when the user enters new lines. (The front end counts line endings as 1 chars (\n) as per HTML spec and the http transport/.net/windows uses 2 chars for line ends (\r\n).)