### PR TITLE
Open footer feedback in same tab

### DIFF
--- a/src/FamilyHubs.Referral.Web/appsettings.json
+++ b/src/FamilyHubs.Referral.Web/appsettings.json
@@ -113,7 +113,7 @@
         { "Text": "Contact Us" },
         { "Text": "Cookies" },
         {
-          "Text": "Feedback",
+          "Text": "Feedback survey",
           "ConfigUrl": "FamilyHubsUi:FeedbackUrl"
         },
         { "Text": "Privacy" },

--- a/src/FamilyHubs.Referral.Web/appsettings.json
+++ b/src/FamilyHubs.Referral.Web/appsettings.json
@@ -114,8 +114,7 @@
         { "Text": "Cookies" },
         {
           "Text": "Feedback",
-          "ConfigUrl": "FamilyHubsUi:FeedbackUrl",
-          "OpenInNewTab": true
+          "ConfigUrl": "FamilyHubsUi:FeedbackUrl"
         },
         { "Text": "Privacy" },
         { "Text": "Terms and conditions" }


### PR DESCRIPTION
Also, rename the link from 'Feedback' to 'Feedback survey'.