### PR TITLE
FHG-4650 Updating data protection act link on Connect T&Cs

### DIFF
--- a/src/FamilyHubs.Referral.Web/Pages/terms-and-conditions/Index.cshtml
+++ b/src/FamilyHubs.Referral.Web/Pages/terms-and-conditions/Index.cshtml
@@ -53,7 +53,7 @@
             <li>the content and availability of external websites that link to the service or which are linked from it</li>
         </ul>
         <h2 class="govuk-heading-m">Data protection</h2>
-        <p>You must comply with all applicable data protection laws, including the <a href="https://www.legislation.gov.uk/ukpga/2018/12/contents/enacted?McasCtx=4&McasTsid=20892">Data Protection Act 2018</a> and the UK GDPR as defined by section 2 of The Data Protection, Privacy and Electronic Communications (Amendments etc) (EU Exit) Regulations 2019, and any regulatory guidance.
+        <p>You must comply with all applicable data protection laws, including the <a href="https://www.gov.uk/data-protection">Data Protection Act 2018</a> and the UK GDPR as defined by section 2 of The Data Protection, Privacy and Electronic Communications (Amendments etc) (EU Exit) Regulations 2019, and any regulatory guidance.
         <p>You understand that:</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>your organisation may act as point of contact for people whose data is being processed</li>


### PR DESCRIPTION
## Context

Need to update the link about the data protection act from the T&Cs in connect - it currently links out to the [legislation.gov.uk](http://legislation.gov.uk/) page which is not best practice. Will link to easier to understand [gov.uk](http://gov.uk/) content.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira ticket

[https://dfedigital.atlassian.net/browse/FHG-123 -->](https://dfedigital.atlassian.net/browse/FHG-4650?atlOrigin=eyJpIjoiODk5NGI5ZmNmNzZjNGYyM2JkOWMwYWM0Yjk0MDlkMjciLCJwIjoiaiJ9)](https://dfedigital.atlassian.net/browse/FHG-4650?atlOrigin=eyJpIjoiODk5NGI5ZmNmNzZjNGYyM2JkOWMwYWM0Yjk0MDlkMjciLCJwIjoiaiJ9)

## Things to check

- [ ] Title is in the format "FHG-XXX: Short description" where FHG-XXX is the Jira ticket reference
- [ ] Code and tests follow the [coding standards](/docs/coding-standards.md)
- [ ] Test coverage of new code is at least 80%
- [ ] All UI related acceptance criteria specified in the ticket have been added to the relevant [cypress test feature file(s)](/Test/cypress/e2e/)
- [ ] Unless explicitly mentioned in the ticket, all UI work should have been tested as working on desktop and mobile resolutions
- [ ] Debug logging has been added after all logic decision points